### PR TITLE
Fix GH build process by using cross-platform pause in tests

### DIFF
--- a/maker-test.ts
+++ b/maker-test.ts
@@ -10,10 +10,7 @@
     for (let i = 0; i < 10; i++) {
         strip.rotate(1);
         strip.show();
-        let b = (basic as any);
-        if (typeof b !== "undefined" && b.pause) {
-            b.pause(100);
-        }
+        pause(100);
     }
 
     strip.clear();

--- a/neotest.ts
+++ b/neotest.ts
@@ -9,39 +9,39 @@
     for (let i = 0; i <= strip.length(); i++) { 
         strip.rotate();
         strip.show();
-        basic.pause(100)
+        pause(100)
     }
     
     strip.showColor(NeoPixelColors.Red)
-    basic.pause(2000)
+    pause(2000)
     strip.showColor(NeoPixelColors.Green)
-    basic.pause(1000)
+    pause(1000)
     for (let i = 0; i <= strip.length(); i++) {
         strip.setPixelColor(i, neopixel.colors(NeoPixelColors.Blue))
         strip.show()
-        basic.pause(100)
+        pause(100)
     }
     for (let i = 0; i <= strip.length(); i++) {
         strip.setPixelColor(i, neopixel.colors(NeoPixelColors.Green))
         strip.show()
-        basic.pause(100)
+        pause(100)
     }
     let sub = strip.range(10, 20)
     sub.showColor(NeoPixelColors.Yellow);
-    basic.pause(200);
+    pause(200);
 
     sub.showBarGraph(5, 10);
-    basic.pause(200);
+    pause(200);
 
     strip.setMatrixWidth(8);
     strip.setMatrixColor(0, 0, NeoPixelColors.Red);
     strip.setMatrixColor(1, 1, NeoPixelColors.Green);
     strip.show();
-    basic.pause(200);
+    pause(200);
 
     strip.easeBrightness();
     strip.show();
-    basic.pause(200);
+    pause(200);
 
     let p = strip.power();
 
@@ -101,6 +101,6 @@
             strip.shift(1);
         }
         strip.show();
-        basic.pause(100);
+        pause(100);
     }
 }


### PR DESCRIPTION
The GitHub build process was failing with `error TS9235: Unknown or undeclared identifier` because `maker-test.ts` was referencing the `basic` namespace, which is only available on the micro:bit target. This PR replaces all instances of `basic.pause()` and the unsafe `(basic as any)` check in both `maker-test.ts` and `neotest.ts` with the global `pause()` function. `pause()` is idiomatic in the PXT environment for cross-target compatibility and correctly delegates to the target-specific implementation at runtime.

Fixes #12

---
*PR created automatically by Jules for task [8699767214439826416](https://jules.google.com/task/8699767214439826416) started by @chatelao*