### PR TITLE
Fix missing NeoPixel initialization block

### DIFF
--- a/neopixel.ts
+++ b/neopixel.ts
@@ -39,7 +39,7 @@ enum NeoPixelMode {
 /**
  * Functions to operate NeoPixel strips.
  */
-//% weight=5 color=#2699BF icon="\uf110"
+//% weight=80 color=#2699BF icon="\uf110"
 namespace neopixel {
     /**
      * A NeoPixel strip
@@ -492,6 +492,7 @@ namespace neopixel {
      * Create a new NeoPixel driver for `numleds` LEDs.
      * @param pin the pin where the neopixel is connected.
      * @param numleds number of leds in the strip, eg: 24,30,60,64
+     * @param mode the color format for the NeoPixel strip, eg: NeoPixelMode.RGB
      */
     //% blockId="neopixel_create" block="NeoPixel at pin %pin|with %numleds|leds as %mode"
     //% weight=90 blockGap=8


### PR DESCRIPTION
The NeoPixel initialization block was "missing" from the MakeCode toolbox due to two main reasons:
1. The low weight (5) of the `neopixel` namespace pushed the category to the bottom of the toolbox or into the "Advanced" sub-menu, making it hard to find.
2. The `create` function was missing JSDoc for its `mode` parameter, which could sometimes cause issues with block generation in the MakeCode editor.

This change increases the namespace weight to 80 and adds the missing JSDoc parameter, matching the official fix in the `microsoft/pxt-neopixel` repository. Testing was performed using `pxt build --cloud` to ensure the project still compiles without errors.

Fixes #15

---
*PR created automatically by Jules for task [4597006092453367704](https://jules.google.com/task/4597006092453367704) started by @chatelao*