### PR TITLE
Add Adafruit MakeCode NeoPixel analysis summary

### DIFF
--- a/ADAFRUIT_MAKECODE_NEOPIXEL.md
+++ b/ADAFRUIT_MAKECODE_NEOPIXEL.md
@@ -1,0 +1,44 @@
+# Adafruit MakeCode NeoPixel (Light) Implementation Analysis
+
+The Adafruit MakeCode "Light" implementation, primarily found in the `light` namespace, is a specialized version of the NeoPixel driver optimized for Adafruit's hardware, particularly the Circuit Playground Express (CPX) and Maker boards.
+
+## Key API Features
+
+The `light` namespace provides a high-level API for controlling NeoPixel rings and strips:
+
+### 1. High-Level Animations
+Adafruit's implementation includes built-in animations that can be triggered with a single command:
+- `light.showAnimation(animation, duration)`: Plays predefined animations like Comet, Rainbow, Sparkle, Running Lights, Theater Chase, and Color Wipe.
+- `light.showRing(colors)`: Sets colors on the onboard NeoPixel ring using a specialized color picker.
+
+### 2. "Photon" Cursor
+A unique "Photon" API allows drawing on the NeoPixel strip using a cursor metaphor:
+- `light.photonForward(steps)`: Moves the cursor forward.
+- `light.photonFlip()`: Reverses the cursor direction.
+- `light.setPhotonPosition(index)`: Sets the cursor to a specific LED.
+- `light.setPhotonPenHue(hue)`: Sets the color of the cursor.
+
+### 3. Color Management
+- `light.hsv(hue, sat, val)`: Supports Hue, Saturation, and Value (Brightness) for color creation.
+- `light.fade(amount, index)`: Provides fading effects for individual pixels or the whole strip.
+
+### 4. Hardware Integration
+- `light.onboardStrip()`: Provides easy access to the built-in NeoPixel ring on supported boards.
+- `light.createStrip(pin, numleds, mode)`: Allows creating drivers for external strips.
+
+## Comparison with `microsoft/pxt-neopixel`
+
+The `microsoft/pxt-neopixel` package (this repository) and Adafruit's `light` namespace serve different purposes:
+
+| Feature | `microsoft/pxt-neopixel` (Current Repo) | Adafruit `light` Namespace |
+|---------|-----------------------------------------|----------------------------|
+| **Primary Namespace** | `neopixel` | `light` |
+| **Target Boards** | Multi-target (micro:bit, Calliope, Maker) | Adafruit-specific (CPX, Maker boards) |
+| **API Level** | Lower-level (Buffer-based, manual control) | High-level (Animations, Photon cursor) |
+| **Animations** | Basic (Rainbow, Bar graph, Shift, Rotate) | Advanced (Comet, Sparkle, Theater Chase, etc.) |
+| **Onboard Support** | Generic (Requires manual pin configuration) | Optimized (Direct access to onboard rings) |
+| **Matrix Support** | Basic 2D matrix support included | Typically handled via separate libraries or simpler mappings |
+
+## Conclusion
+
+Adafruit's "Light" implementation is designed for rapid prototyping and ease of use on their own boards, providing complex visual effects with minimal code. The `microsoft/pxt-neopixel` package is a more portable and flexible driver intended for a wider range of hardware targets where manual control over the LED buffer is more common.


### PR DESCRIPTION
Created a comprehensive summary document, `ADAFRUIT_MAKECODE_NEOPIXEL.md`, analyzing the Adafruit MakeCode NeoPixel (Light) implementation. The analysis covers key API features such as built-in animations (Comet, Rainbow, Sparkle, etc.), the unique "Photon" cursor-based drawing system, and color management. It also provides a direct comparison with the more generic `microsoft/pxt-neopixel` driver used in this repository, noting differences in API level, target hardware support, and animation capabilities. Repository integrity was verified using `pxt build --cloud` for the micro:bit target.

Fixes #16

---
*PR created automatically by Jules for task [4827146613955060997](https://jules.google.com/task/4827146613955060997) started by @chatelao*