### PR TITLE
restore original NeoPixel initialization block

### DIFF
--- a/_locales/de/neopixel-strings.json
+++ b/_locales/de/neopixel-strings.json
@@ -28,7 +28,7 @@
   "neopixel.Strip.showRainbow|block": "%strip|zeige Regenbogen von Farbton %startHue|bis %endHue",
   "neopixel.Strip.show|block": "%strip|anzeigen",
   "neopixel.colors|block": "%color",
-  "neopixel.create|block": "NeoPixels an Pin %pin|mit %numleds|Pixeln und Modus %mode",
+  "neopixel.create|block": "NeoPixels an Pin %pin|mit %numleds|Pixeln || und Modus %mode",
   "neopixel.hsl|block": "HSL-Farbe: Farbwert %hue|Sättigung %sat|Helligkeit %lum",
   "neopixel.Strip.power|block": "%strip|Stromverbrauch (mA)",
   "neopixel.rgb|block": "rot %red|grün %green|blau %blue",

--- a/_locales/es-ES/neopixel-strings.json
+++ b/_locales/es-ES/neopixel-strings.json
@@ -29,7 +29,7 @@
   "neopixel.Strip.showRainbow|block": "mostrar arcoiris en %strip|desde %startHue|hasta %endHue",
   "neopixel.Strip.show|block": "mostrar %strip|",
   "neopixel.colors|block": "%color",
-  "neopixel.create|block": "NeoPixel en pin %pin|con %numleds|LEDs en %mode",
+  "neopixel.create|block": "NeoPixel en pin %pin|con %numleds|LEDs || en %mode",
   "neopixel.hsl|block": "matiz %h|saturación %s|luminosidad %l",
   "neopixel.rgb|block": "R(rojo) %red|G(verde) %green|B(azul) %blue",
   "neopixel|block": "neopixel",

--- a/_locales/fr/neopixel-strings.json
+++ b/_locales/fr/neopixel-strings.json
@@ -29,7 +29,7 @@
   "neopixel.Strip.showRainbow|block": "afficher arc-en-ciel sur %strip|de %startHue|à %endHue",
   "neopixel.Strip.show|block": "montrer %strip|",
   "neopixel.colors|block": "%color",
-  "neopixel.create|block": "NeoPixel sur broche %pin|avec %numleds|DELs en %mode",
+  "neopixel.create|block": "NeoPixel sur broche %pin|avec %numleds|DELs || en %mode",
   "neopixel.hsl|block": "teinte %h|saturation %s|luminosité %l",
   "neopixel.rgb|block": "R %red|G %green|B %blue",
   "neopixel|block": "neopixel",

--- a/_locales/ja/neopixel-strings.json
+++ b/_locales/ja/neopixel-strings.json
@@ -24,7 +24,7 @@
   "neopixel.Strip.range|block": "%strip|の%start|番目から%length|個のNeoPixel",
   "neopixel.Strip.shift|block": "%strip|に設定されている色をLED%offset|個分ずらす",
   "neopixel.Strip.rotate|block": "%strip|に設定されている色をLED%offset|個分ずらす（ひとまわり）",
-  "neopixel.create|block": "端子%pin|に接続しているLED|%numleds|個のNeoPixel（モード%mode|）",
+  "neopixel.create|block": "端子%pin|に接続しているLED|%numleds|個のNeoPixel || （モード%mode|）",
   "neopixel.rgb|block": "RGB（赤%red|緑%green|青%blue|）",
   "neopixel.colors|block": "%color",
   "neopixel.HSL.rotateHue|block": "HSL%hsl|の色相を%offset|ずらす",

--- a/_locales/zh/neopixel-strings.json
+++ b/_locales/zh/neopixel-strings.json
@@ -29,6 +29,6 @@
   "neopixel.power|block": "%strip| 电流(mA)",
   "neopixel.setMatrixWidth|block": "%strip|设置矩阵宽度 %width",
   "neopixel.setMatrixColor|block": "%string|设置像素点 （坐标）x %x|y %y|颜色 %rgb=neopixel_colors",
-  "neopixel.create|block": "引脚%pin|初始化灯带|%numleds|颗LED（模式%mode|）",
+  "neopixel.create|block": "引脚%pin|初始化灯带|%numleds|颗LED || （模式%mode|）",
   "neopixel.rgb|block": "RGB（红%red|绿%green|蓝%blue|）"
 }

--- a/neopixel.ts
+++ b/neopixel.ts
@@ -492,12 +492,16 @@ namespace neopixel {
      * Create a new NeoPixel driver for `numleds` LEDs.
      * @param pin the pin where the neopixel is connected.
      * @param numleds number of leds in the strip, eg: 24,30,60,64
+     * @param mode formulation of the pixel (RGB, RGBW, ...)
      */
-    //% blockId="neopixel_create" block="NeoPixel at pin %pin|with %numleds|leds as %mode"
+    //% blockId="neopixel_create" block="NeoPixel at pin %pin|with %numleds|leds || as %mode"
     //% weight=90 blockGap=8
     //% parts="neopixel"
     //% trackArgs=0,2
     //% blockSetVariable=strip
+    //% pin.defl=DigitalPin.P0
+    //% numleds.defl=24
+    //% mode.defl=NeoPixelMode.RGB
     export function create(pin: DigitalPin, numleds: number, mode: NeoPixelMode): Strip {
         let strip = new Strip();
         let stride = mode === NeoPixelMode.RGBW ? 4 : 3;


### PR DESCRIPTION
Restored the original NeoPixel initialization block by making the 'mode' parameter optional in the MakeCode block editor UI. This was achieved using the '||' syntax in the block annotation and adding default value annotations ('//% pin.defl', etc.). All localized strings were also updated to maintain consistency across languages. verified through code inspection and metadata validation.

Fixes #18

---
*PR created automatically by Jules for task [3812029779066420232](https://jules.google.com/task/3812029779066420232) started by @chatelao*