### PR TITLE
Fix 'DigitalPin' compilation error in Maker target

### DIFF
--- a/neopixel.ts
+++ b/neopixel.ts
@@ -615,3 +615,10 @@ namespace neopixel {
         Shortest
     }
 }
+
+namespace ws2812b {
+    /**
+     * DigitalPin interface to satisfy the compiler in targets where it is not defined.
+     */
+    export interface DigitalPin { }
+}


### PR DESCRIPTION
Add a placeholder `DigitalPin` interface to `neopixel.ts` inside the `ws2812b` namespace. This resolves a "Cannot find name 'DigitalPin'" error during compilation for the 'maker' target, which lack a global definition of `DigitalPin`. The approach ensures compatibility with targets that already have `DigitalPin` defined by isolating the declaration within the specific namespace used by the failing dependency.

Fixes #34

---
*PR created automatically by Jules for task [10507086490907339377](https://jules.google.com/task/10507086490907339377) started by @chatelao*