### PR TITLE
Restore missing neopixel initialization block

### DIFF
--- a/neopixel.ts
+++ b/neopixel.ts
@@ -397,7 +397,7 @@ namespace neopixel {
          */
         //% weight=10
         //% parts="neopixel" advanced=true
-        setPin(pin: any): void {
+        setPin(pin: DigitalPin): void {
             this.pin = pin;
             const _this = (this as any);
             let p = _this["pin" + "s"];
@@ -522,7 +522,8 @@ namespace neopixel {
     //% parts="neopixel"
     //% trackArgs=0,2
     //% blockSetVariable=strip
-    export function create(pin: any, numleds: number, mode: NeoPixelMode): Strip {
+    //% pin.shadow="digitalpin_shim"
+    export function create(pin: DigitalPin, numleds: number, mode: NeoPixelMode): Strip {
         let strip = new Strip();
         let stride = mode === NeoPixelMode.RGBW ? 4 : 3;
         strip.buf = pins.createBuffer(numleds * stride);


### PR DESCRIPTION
This change updates the 'neopixel.create' and 'Strip.setPin' functions to use the 'DigitalPin' type instead of 'any'. It also adds the '//% pin.shadow="digitalpin_shim"' annotation to 'neopixel.create'. These changes are necessary for the MakeCode block editor to correctly identify the pin parameter and render the corresponding initialization block in the toolbox.

Fixes #37

---
*PR created automatically by Jules for task [1073143034128473059](https://jules.google.com/task/1073143034128473059) started by @chatelao*